### PR TITLE
Update the MathJax CDN source to the one suggested. 

### DIFF
--- a/src/option.es6
+++ b/src/option.es6
@@ -3,7 +3,7 @@ import _ from 'underscore'
 export const DEFAULT_OPTS = {
   engine: 'mathjax',
   mathjax: {
-    src: "//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML",
+    src: "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js",
     config: {
       tex2jax: {
         inlineMath: [ ['$','$'], ["\\(","\\)"] ],


### PR DESCRIPTION
This addresses issue #41, and points to the suggested CDN for MathJax, as the current URL in the code points to a site that is shutting down.