### PR TITLE
https support

### DIFF
--- a/src/option.es6
+++ b/src/option.es6
@@ -3,7 +3,7 @@ import _ from 'underscore'
 export const DEFAULT_OPTS = {
   engine: 'mathjax',
   mathjax: {
-    src: "//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML",
+    src: "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML",
     config: {
       tex2jax: {
         inlineMath: [ ['$','$'], ["\\(","\\)"] ],


### PR DESCRIPTION
Changed Mathjax source link into https form to support GitHub Page and https servers.