### PR TITLE
chore(deps): update mathjax from 3.0.5 to 3.1.0

### DIFF
--- a/lib/mathjax.js
+++ b/lib/mathjax.js
@@ -17,8 +17,6 @@ module.exports = hexo => {
 
     const MathJax = await init({
       loader: {
-        // https://github.com/mathjax/MathJax/issues/2486
-        paths: { mathjax: 'mathjax/es5' },
         load: ['input/tex', 'output/svg']
       },
       tex,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "hexo-util": "^2.2.0",
     "katex": "^0.12.0",
-    "mathjax": "^3.0.5"
+    "mathjax": "^3.1.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
https://github.com/mathjax/MathJax/issues/2486 is fixed and WIndows workaround is no longer required.