### PR TITLE
test: delete requie `register-should` in `.mocharc.yml`

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -3,5 +3,3 @@ reporter: spec
 ui: bdd
 full-trace: true
 exit: true
-require:
-  - "chai/register-should"


### PR DESCRIPTION
The current test seems to be failing due to this option.
Perhaps, no need to specify  `chai/register-should`  in `.mocharc.yml` as chai's docs.

> https://github.com/chaijs/chai/tree/7bc01d6fc0741bccfdab7c84bec538c8879f93d7#usage